### PR TITLE
fix: reducing duplicate header file definitions

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -56,11 +56,9 @@
 #include <limits.h>
 #include <float.h>
 #include <math.h>
-#include <sys/resource.h>
 #include <sys/utsname.h>
 #include <locale.h>
 #include <sys/socket.h>
-#include <sys/resource.h>
 
 #ifdef __linux__
 #include <sys/mman.h>


### PR DESCRIPTION
Reducing duplicate header file definitions <sys/resource.h>